### PR TITLE
Give credit to original library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ $ cd react-native-gallery-swiper/example/
 
 Free and made possible along with costly maintenance and updates by [Lue Hang](https://www.facebook.com/lue.hang) (the author).
 
+Originally based off [react-native-image-gallery](https://github.com/archriss/react-native-image-gallery).
+
 <br/>
 <br/>
 <br/>


### PR DESCRIPTION
I was searching for whether someone else in the community continued development after [react-native-image-gallery](https://github.com/archriss/react-native-image-gallery) stopped being maintained.

I'm glad to see it's still under active development here. :-) It does seem appropriate to credit the original library though.